### PR TITLE
Keep looping on events if one loop errors out.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep looping on events if one loop errors out.
+
 ## [0.1.1] - 2021-01-27
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func main() {
 			events, err := azureMetadata.FetchEvents()
 			if err != nil {
 				logger.Errorf(ctx, err, "Error fetching events from azure metadata service")
-				break
+				continue
 			}
 
 			for _, event := range events {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15846

if an execution of the main loop failed for whatever reason, the loop exited and the events weren't handled anymore.
This PR aims at fixing just that