### PR TITLE
Remove the `Node` from Kubernetes API server before approving event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Remove the `Node` from Kubernetes API server right before approving the termination event.
+
 ### Fixed
 
 - Keep looping on events if one loop errors out.

--- a/helm/azure-scheduled-events-app/templates/rbac.yaml
+++ b/helm/azure-scheduled-events-app/templates/rbac.yaml
@@ -12,6 +12,7 @@ rules:
     verbs:
       - "get"
       - "patch"
+      - "delete"
   - apiGroups:
       - ""
     resources:

--- a/pkg/eventhandler/drainer/drain.go
+++ b/pkg/eventhandler/drainer/drain.go
@@ -21,7 +21,10 @@ import (
 func (s *DrainEventHandler) drainNode(ctx context.Context, k8sclient kubernetes.Interface, nodename string) error {
 	s.Logger.Debugf(ctx, "Getting node %q for draining", nodename)
 	node, err := k8sclient.CoreV1().Nodes().Get(ctx, nodename, metav1.GetOptions{})
-	if err != nil {
+	if apierrors.IsNotFound(err) {
+		s.Logger.Debugf(ctx, "Node %q was not found, it was probably already drained and deleted", nodename)
+		return nil
+	} else if err != nil {
 		return microerror.Mask(err)
 	}
 

--- a/pkg/eventhandler/drainer/drain.go
+++ b/pkg/eventhandler/drainer/drain.go
@@ -21,7 +21,9 @@ import (
 func (s *DrainEventHandler) drainNode(ctx context.Context, k8sclient kubernetes.Interface, nodename string) error {
 	s.Logger.Debugf(ctx, "Getting node %q for draining", nodename)
 	node, err := k8sclient.CoreV1().Nodes().Get(ctx, nodename, metav1.GetOptions{})
-	if err != nil {
+	if apierrors.IsNotFound(err) {
+		s.Logger.Debugf(ctx, "Node %q was not found, it was probably already drained and deleted", s.LocalNodeName)
+	} else if err != nil {
 		return microerror.Mask(err)
 	}
 

--- a/pkg/eventhandler/drainer/drain.go
+++ b/pkg/eventhandler/drainer/drain.go
@@ -23,6 +23,7 @@ func (s *DrainEventHandler) drainNode(ctx context.Context, k8sclient kubernetes.
 	node, err := k8sclient.CoreV1().Nodes().Get(ctx, nodename, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		s.Logger.Debugf(ctx, "Node %q was not found, it was probably already drained and deleted", s.LocalNodeName)
+		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/eventhandler/drainer/drain.go
+++ b/pkg/eventhandler/drainer/drain.go
@@ -21,10 +21,7 @@ import (
 func (s *DrainEventHandler) drainNode(ctx context.Context, k8sclient kubernetes.Interface, nodename string) error {
 	s.Logger.Debugf(ctx, "Getting node %q for draining", nodename)
 	node, err := k8sclient.CoreV1().Nodes().Get(ctx, nodename, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		s.Logger.Debugf(ctx, "Node %q was not found, it was probably already drained and deleted", nodename)
-		return nil
-	} else if err != nil {
+	if err != nil {
 		return microerror.Mask(err)
 	}
 

--- a/pkg/eventhandler/drainer/drainer.go
+++ b/pkg/eventhandler/drainer/drainer.go
@@ -40,8 +40,6 @@ func (s *DrainEventHandler) HandleEvent(ctx context.Context, event azuremetadata
 		err := s.drainNode(ctx, s.K8sClient, s.LocalNodeName)
 		if IsEvictionInProgress(err) {
 			s.Logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("node %q not drained in time.", s.LocalNodeName))
-		} else if apierrors.IsNotFound(err) {
-			s.Logger.Debugf(ctx, "Node %q was not found, it was probably already drained and deleted", s.LocalNodeName)
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {


### PR DESCRIPTION
towards: https://github.com/giantswarm/giantswarm/issues/15637

Sometimes it takes a while for the controller manager to detect one node is gone (thank you azure cache).
This PR adds a feature that removes the Node Resource of a node being terminated after it's drained but before the termination event is approved. It makes things such as upgrades a little bit quicker.