### PR TITLE
React to more events for auto node draining feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- React to `Preempt`, `Reboot` and ` case `Redeploy` events to drain nodes properly.
+
+### Change
+
+- Use the `NotBefore` field from the event to calculate drain timeout.
+
 ## [0.3.0] - 2021-03-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- React to `Preempt`, `Reboot` and ` case `Redeploy` events to drain nodes properly.
+- React to `Preempt`, `Reboot` and `Redeploy` events to drain nodes properly.
 
 ### Change
 

--- a/pkg/azuremetadataclient/azuremetadataclient.go
+++ b/pkg/azuremetadataclient/azuremetadataclient.go
@@ -98,6 +98,10 @@ func (am *Client) FetchEvents() ([]ScheduledEvent, error) {
 	var filtered []ScheduledEvent
 
 	for _, event := range response.Events {
+		// Check if event ResourceType is VirtualMachine
+		if event.ResourceType != "VirtualMachine" {
+			continue
+		}
 		// Check if event is related to the local instance.
 		for _, resource := range event.Resources {
 			if resource == am.localInstanceVMName {

--- a/pkg/eventhandler/drainer/drainer.go
+++ b/pkg/eventhandler/drainer/drainer.go
@@ -3,6 +3,7 @@ package drainer
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -33,11 +34,33 @@ func NewDrainEventHandler(logger micrologger.Logger, client *azuremetadataclient
 
 func (s *DrainEventHandler) HandleEvent(ctx context.Context, event azuremetadataclient.ScheduledEvent) error {
 	s.Logger.Debugf(ctx, "Received event: %v", event)
-	if event.EventType == "Terminate" && event.ResourceType == "VirtualMachine" {
-		s.Logger.LogCtx(ctx, "message", "found Terminate event, start draining the node")
+
+	var timeout time.Duration
+	{
+		t, err := time.Parse(time.RFC1123, event.NotBefore)
+		if err != nil {
+			timeout = 15 * time.Minute
+		} else {
+			timeout = time.Until(t)
+		}
+	}
+
+	switch event.EventType {
+	case "Terminate":
+	case "Preempt":
+	case "Reboot":
+	case "Redeploy":
+	default:
+		s.Logger.Debugf(ctx, "Warning: unhandled event type: %s (resource type %s)", event.EventType, event.ResourceType)
+		return nil
+	}
+
+	// If timeout is negative we have no time to drain the node, so we skip the step.
+	if timeout > 0 {
+		s.Logger.Debugf(ctx, "got event %s, start draining the node (timeout %.0f seconds)", event.EventType, timeout.Seconds())
 
 		// Drain the node.
-		err := s.drainNode(ctx, s.K8sClient, s.LocalNodeName)
+		err := s.drainNode(ctx, s.K8sClient, s.LocalNodeName, timeout)
 		if IsEvictionInProgress(err) {
 			s.Logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("node %q not drained in time.", s.LocalNodeName))
 		} else if err != nil {
@@ -45,23 +68,23 @@ func (s *DrainEventHandler) HandleEvent(ctx context.Context, event azuremetadata
 		} else {
 			s.Logger.Debugf(ctx, fmt.Sprintf("node %q drained successfully.", s.LocalNodeName))
 		}
-
-		// Delete node from k8s.
-		s.Logger.Debugf(ctx, "Deleting Node %q from k8s API", s.LocalNodeName)
-		err = s.K8sClient.CoreV1().Nodes().Delete(ctx, s.LocalNodeName, v1.DeleteOptions{})
-		if apierrors.IsNotFound(err) {
-			s.Logger.Debugf(ctx, "Node %q was not found, it was probably already deleted", s.LocalNodeName)
-		} else if err != nil {
-			s.Logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("Error deleting node %q from Kubernetes API: %s.", s.LocalNodeName, err))
-		}
-
-		// ACK the event to complete termination.
-		err = s.AzureMetadataClient.AckEvent(event.EventId)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-		s.Logger.LogCtx(ctx, "message", fmt.Sprintf("acked event %q", event.EventId))
 	}
+
+	// Delete node from k8s.
+	s.Logger.Debugf(ctx, "Deleting Node %q from k8s API", s.LocalNodeName)
+	err := s.K8sClient.CoreV1().Nodes().Delete(ctx, s.LocalNodeName, v1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		s.Logger.Debugf(ctx, "Node %q was not found, it was probably already deleted", s.LocalNodeName)
+	} else if err != nil {
+		s.Logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("Error deleting node %q from Kubernetes API: %s.", s.LocalNodeName, err))
+	}
+
+	// ACK the event.
+	err = s.AzureMetadataClient.AckEvent(event.EventId)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	s.Logger.LogCtx(ctx, "message", fmt.Sprintf("acked event %q", event.EventId))
 
 	return nil
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16642

This PR adds a few more events among the one handled by the `drainer` event handler.
This means that the node will be drained not only on `termination` (as it was already doing before this PR) but also:

- when rebooted from azure portal
- when preempted by azure (spot instances)
- when redeployed by azure (moved to a different hardware node).

Also interestingly, we now set up drain expiration based on the event itself rather than hardcoding a fixed timeout.
That's useful because different events have different time outs (spot instances preemption has a 2 minutes timeout while termination has 15 for example).