### PR TITLE
Add toleration to schedule pod on master nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add toleration to schedule pod on master nodes.
+
 ## [0.6.1] - 2022-03-14
 
 ### Changed

--- a/helm/azure-scheduled-events-app/templates/daemonset.yaml
+++ b/helm/azure-scheduled-events-app/templates/daemonset.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         {{- include "labels.common" . | nindent 8 }}
     spec:
+      tolerations:
+      - operator: Exists
       serviceAccountName: {{ include "resource.default.name"  . }}
       priorityClassName: "system-node-critical"
       containers:


### PR DESCRIPTION
On MCs the scheduled events app needs to run in all nodes, including masters.
We need to add a toleration for this to happen.

this PR does just that